### PR TITLE
Fix the text for DNS zones

### DIFF
--- a/lib/hub-clusters-creator/providers/aks/schema.yaml
+++ b/lib/hub-clusters-creator/providers/aks/schema.yaml
@@ -101,8 +101,8 @@ properties:
     title: DNS Domain
     default: ''
     description: >
-      The dns domain which the cluster is using; this mist be accessible from
-      with inside the project.
+      All DNS records for the cluster will created within this domain;
+      this must be a domain accessible from the Azure project.
     examples:
       - 'example.com'
 

--- a/lib/hub-clusters-creator/providers/eks/schema.yaml
+++ b/lib/hub-clusters-creator/providers/eks/schema.yaml
@@ -98,8 +98,8 @@ properties:
     title: DNS Domain
     default: ''
     description: >
-      The dns domain which the cluster is using; this mist be accessible from
-      with inside the project.
+      All DNS records for the cluster will created within this domain;
+      this must be a route53 domain accessible from the AWS project.
     examples:
       - 'example.com'
 

--- a/lib/hub-clusters-creator/providers/gke/schema.yaml
+++ b/lib/hub-clusters-creator/providers/gke/schema.yaml
@@ -105,8 +105,8 @@ properties:
     title: DNS Domain
     default: ''
     description: >
-      The dns domain which the cluster is using; this mist be accessible from
-      with inside the project.
+      All DNS records for the cluster will created within this domain;
+      this must be a Cloud DNS domain accessible from the Google Cloud project.
     examples:
       - 'example.com'
 


### PR DESCRIPTION
Fixed the word ~mist~ to be must - but then changed the text completely given what is done here.