### PR TITLE
auto_assign_org_role: Editor

### DIFF
--- a/lib/hub-clusters-creator/providers/bootstrap.erb.yaml
+++ b/lib/hub-clusters-creator/providers/bootstrap.erb.yaml
@@ -103,6 +103,8 @@ data:
           mode: console
         grafana_net:
           url: https://grafana.net
+        users:
+          auto_assign_org_role: Editor
         <%- unless (context[:github_client_id] || '').empty? -%>
         auth.github:
           allow_sign_up: true


### PR DESCRIPTION
- Editor required to view loki logs within explore tab of grafana